### PR TITLE
lib/file/mode: clean up conversion

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,10 @@
   value should be converted, use `default_conf_string`.
   ([#89](https://github.com/flyingcircusio/batou/issues/89))
 
+- Enhance file `Mode` objects to accept integers, octal mode strings
+  and 'rwx' strings as the `mode` argument. This allows homogenous use
+  in Python code and overrides through config files.
+
 - Do not render diffs for files which contain contents of `secrets/*`.
   ([#91](https://github.com/flyingcircusio/batou/issues/91))
 

--- a/doc/source/components/files.txt
+++ b/doc/source/components/files.txt
@@ -68,7 +68,7 @@ Creates a file. The main parameter for File is the target path. A ``File`` insta
 
 .. py:attribute:: mode
 
-    Unix permission mode (octal number, e.g. 0o755)
+    Unix permission mode. Can be given as an integer value (`0o755`) or as an octal integer string (`'755'`) or as a unix mode string similar to the output of `ls -l` (`'rwx--x--x'`).
 
 .. py:attribute:: leading
 

--- a/src/batou/lib/tests/test_file.py
+++ b/src/batou/lib/tests/test_file.py
@@ -7,6 +7,7 @@ import os
 import pwd
 from stat import S_IMODE
 
+import batou
 import pytest
 import yaml
 from batou.lib.file import (BinaryFile, Content, Directory, File,
@@ -854,6 +855,25 @@ def test_mode_ensures_mode_for_files(root):
 
     root.component.deploy()
     assert not mode.changed
+
+
+def test_mode_converts_to_numeric(root):
+    path = "path"
+    open("work/mycomponent/" + path, "w").close()
+
+    with pytest.raises(batou.ConfigurationError) as e:
+        mode = Mode(path)
+        root.component += mode
+    assert str(
+        e.value) == '`mode` is required and `None` is not a valid value.`'
+
+    mode = Mode(path, mode='rwx------')
+    root.component += mode
+    assert mode.mode == 0o700
+
+    mode = Mode(path, mode='500')
+    root.component += mode
+    assert mode.mode == 0o500
 
 
 def test_mode_ensures_mode_for_directories(root):


### PR DESCRIPTION
This provides a more coherent way of dealing with the multi-type
argument (integer, integer-as-string and unix-permission-string)
both from config files and from pure Python code. This might
become a pattern in the future?

This implementation is also fully backwards compatible to existing
deployments.